### PR TITLE
Added Gainers Losers API

### DIFF
--- a/api/chartjs_classes.py
+++ b/api/chartjs_classes.py
@@ -585,3 +585,114 @@ def pcr_linegraph(label_ticker,scale_label_str):
 				]
 			}
 	return LineGraph
+
+def gl_bargraph(data1,yaxis_labels,y_label,top_label,barcolor="GREEN",position='left',len1=None,len2=None):
+    class BarGraph(BaseChart):
+
+        type = ChartType.HorizontalBar
+        
+        class labels:
+            yaxis_labels = list()
+
+        class data:
+            pass
+
+        class options:
+            indexAxis = 'y'
+            responsive = True
+            tooltips = {
+                            "intersect"         : False,
+                            # "mode"              : "nearest",
+                            "mode"              : "index",
+                            "axis"              : "y",
+                            "position"          : "nearest",
+                            "displayColors"     : True
+                            # "cornerRadius"      : 3
+            }
+
+            legend = {
+                            'position'      : 'top', 
+                            'labels'        : {
+                            'fontColor'     : Color.Black, 
+                            "boxWidth"      : 35,
+                            # 'fullWidth'   : True,
+                            "fontSize"      : 16,
+                            "fontStyle"     : "bold"
+                            # "padding"     : 50,
+                            # "usePointStyle" : True
+                        }
+            }
+            
+
+            scales = None
+
+    class bardata1:
+        label           = "Gainers Losers"
+        data            = []
+        axis            = 'y'
+        #Border properties
+        borderColor     = Color.Black
+        borderWidth     = 1
+        backgroundColor = None
+        fill            = True
+
+    class bardata2:
+        label           = "Gainers Losers"
+        data            = []
+        axis            = 'y'
+        #Border properties
+        borderColor     = Color.Black
+        borderWidth     = 1
+        backgroundColor = None
+        fill            = True
+
+
+
+    BarGraph.data.bardata1 = bardata1
+    BarGraph.data.bardata1.data = data1
+    BarGraph.labels.yaxis_labels = yaxis_labels
+    BarGraph.data.bardata1.backgroundColor = Color.Green if barcolor == "GREEN" \
+                                            else Color.Red if  barcolor == "RED" \
+                                            else ([Color.Green]*len1)+([Color.Red]*len2)
+    BarGraph.data.bardata1.label = top_label
+
+    # if data2 is not None: 
+    #     BarGraph.data.bardata2 = bardata2
+    #     BarGraph.data.bardata2.data = data2
+    #     BarGraph.data.bardata2.backgroundColor = Color.Red
+    #     BarGraph.data.bardata2.label = "LOOSERS"
+
+    BarGraph.options.scales = {
+
+                "xAxes": [
+                        {   
+                           
+                           "display"        : True,
+                           "labelString"    : "Percent Gain" ,
+                            "gridLines"     : {
+                                "display"      : True,
+                                "drawBorder"   : True
+                            }, 
+                    }
+                ],
+                "yAxes": [
+                        {
+                            "scaleLabel": {
+                                            "display"       : True,
+                                            "labelString"   : "NSE "+y_label,
+                                            "fontColor"     : Color.Black,
+                                            "fontSize"      : 16
+                                }, 
+                            "id"            : "y1",
+                            "position"      : position,
+                            "display"       : True,
+                            "gridLines"     : {
+                                                "display"     : True
+                                            # "drawBorder"    : True
+                        }
+                    }
+                   
+                ]
+            }
+
+    return BarGraph

--- a/api/classes.py
+++ b/api/classes.py
@@ -44,6 +44,7 @@ class KiteAuthentication:
         self.kiteauth_table_name = 'kiteauth'
         self.ticker = ''
         self.kite_login_success = False
+        self.pg = None
         if self.request_token is None:
             self.read_access_details_usingdb()
         self.get_login()
@@ -51,8 +52,8 @@ class KiteAuthentication:
     def read_access_details_usingdb(self):
         
         ####PLease uncomment here later###
-        pg = PostgreSQLOperations()
-        df = pg.get_postgres_data_df_with_condition(table_name=self.kiteauth_table_name) 
+        self.pg = PostgreSQLOperations()
+        df = self.pg.get_postgres_data_df_with_condition(table_name=self.kiteauth_table_name) 
         self.access_token = df['access_token'].values[0]
         ###PLease uncomment here later###
         

--- a/api/classes.py
+++ b/api/classes.py
@@ -468,70 +468,164 @@ class KiteFunctions(KiteAuthentication):
         
         return last_traded_dates
 
-    def get_gainers_losers_close_df(self,gnlr_type,expiry_date=None):
-        stock_df = None
-        if gnlr_type == "STOCKS":
-            stock_df = (
-                self.master_instruments_df[
-                    self.master_instruments_df["segment"] == "NFO-FUT"
+    def get_gainers_losers_close_df(self, gnlr_type, expiry_date=None,from_date=None,to_date=None):
+        #**********************************************************************************************************
+        #**********************************************************************************************************
+        if (from_date is None) and (to_date is None):
+            # print("From to dates none")
+            stock_df = None
+            if gnlr_type == "STOCKS":
+                stock_df = (
+                    self.master_instruments_df[
+                        self.master_instruments_df["segment"] == "NFO-FUT"
+                    ]
+                    .groupby("name")
+                    .first()
+                    .reset_index()
+                )
+
+                stock_df["exchange_tradingsymbol"] = stock_df.apply(
+                    lambda x: "NSE:" + x["name"], axis=1
+                )
+
+            elif gnlr_type == "INDICES":
+                stock_df = (
+                    self.master_instruments_df[
+                        (self.master_instruments_df["segment"] == "INDICES")
+                        & (self.master_instruments_df["exchange"] == "NSE")
+                        & ~(self.master_instruments_df["name"] == "NIFTY50 DIV POINT")
+                    ]
+                    .groupby("name")
+                    .first()
+                    .reset_index()
+                )
+
+                stock_df["exchange_tradingsymbol"] = stock_df.apply(
+                    lambda x: "NSE:" + x["name"], axis=1
+                )
+
+            elif  gnlr_type == "FUTURES":
+                stock_df = self.master_instruments_df[
+                    (self.master_instruments_df["segment"] == "NFO-FUT")
+                    & (self.master_instruments_df["expiry"] == expiry_date)
+                    & ~(
+                        self.master_instruments_df["name"].isin(
+                            ["NIFTY", "BANKNIFTY", "FINNIFTY"]
+                        )
+                    )
                 ]
-                .groupby("name")
-                .first()
-                .reset_index()
+                # breakpoint()
+                stock_df = pd.concat(
+                    [
+                        stock_df,
+                        stock_df.loc[:, "tradingsymbol"].apply(lambda x: "NFO:" + x),
+                    ],
+                    axis=1,
+                )
+                stock_df.columns.values[-1] = "exchange_tradingsymbol"
+
+        # if from_date is None and to_date is None:
+            res_df = (
+                pd.DataFrame(self.kite.quote(stock_df["exchange_tradingsymbol"].tolist()))
+                .transpose()
+                .apply(
+                    lambda x: [
+                        x["last_price"],
+                        x["ohlc"]["close"],
+                        x["last_price"] - x["ohlc"]["close"],
+                        ((x["last_price"] - x["ohlc"]["close"]) / x["ohlc"]["close"]) * 100,
+                    ]
+                    if x["ohlc"]["close"] != 0
+                    else [x["last_price"], x["ohlc"]["close"], None, None],
+                    axis=1,
+                )
             )
 
-            stock_df["exchange_tradingsymbol"] = stock_df.apply(
-                lambda x: "NSE:" + x["name"], axis=1
+            res_df = pd.DataFrame(
+                res_df.to_list(),
+                index=res_df.index.to_series().apply(lambda x: x.split(":")[1]).tolist(),
+                columns=["prev_close", "curr_close", "diff", "percent_diff"],
             )
 
-        elif gnlr_type == "INDICES":
-            stock_df = (
-                self.master_instruments_df[
-                    (self.master_instruments_df["segment"] == "INDICES")
-                    & (self.master_instruments_df["exchange"] == "NSE")
-                    & ~(self.master_instruments_df["name"] == "NIFTY50 DIV POINT")
-                ]
-                .groupby("name")
-                .first()
-                .reset_index()
-            )
-
-            stock_df["exchange_tradingsymbol"] = stock_df.apply(
-                lambda x: "NSE:" + x["name"], axis=1
-            )
-
-        else:
-            stock_df = self.master_instruments_df[
-                (self.master_instruments_df["segment"] == "NFO-FUT")
-                & (self.master_instruments_df["expiry"] == expiry_date)
-                & ~(self.master_instruments_df["name"].isin(["NIFTY", "BANKNIFTY", "FINNIFTY"]))
-            ]
+            res_df.dropna(inplace=True)
+            res_df.sort_values(by="percent_diff", ascending=False, inplace=True)
+            res_df = res_df.round(2)
             # breakpoint()
-            stock_df = pd.concat(
+            return res_df
+
+        #**********************************************************************************************************
+        #**********************************************************************************************************
+
+        elif (from_date is not None) and (to_date is not None):
+            # print("From to dates not none")
+            # if to_date == date.today():
+            #     pass
+            # else:
+
+            if gnlr_type == "STOCKS":
+                pass
+
+            elif gnlr_type == "INDICES":
+                pass
+
+            elif gnlr_type == "FUTURES": # 7.32 secs number -> 5
+                res_df = self.ka.pg.get_postgres_data_df_with_condition(
+                            table_name="stock_futures_history_day",
+                            where_condition="where CAST(last_update AS DATE) = '{}' ".format(
+                                from_date
+                            )+
+                            "and CAST(expiry_date as DATE) = '{}'".format(
+                                expiry_date
+                            ),
+                        )
+                # breakpoint()
+                res_df.columns.values[6] = "prev_close"
+                res_indx = res_df['ticker']
+                # breakpoint()
+                res_df = pd.concat(
                 [
-                    stock_df,
-                    stock_df.loc[:, "tradingsymbol"].apply(lambda x: "NFO:" + x),
+                    res_df,
+                    self.ka.pg.get_postgres_data_df_with_condition(
+                        table_name="stock_futures_history_day",
+                        where_condition="where CAST(last_update AS DATE) = '{}' ".format(
+                            to_date
+                        )+
+                        "and CAST(expiry_date as DATE) = '{}'".format(
+                            expiry_date
+                        ),
+                    ),
                 ],
                 axis=1,
-            )
-            stock_df.columns.values[-1] = "exchange_tradingsymbol"
-        res_df = pd.DataFrame(self.kite.quote(
-            stock_df["exchange_tradingsymbol"].tolist())).transpose().apply(
-        lambda x:[
-        x['last_price'],x['ohlc']['close'],
-        x["last_price"] - x["ohlc"]["close"],
-        ((x["last_price"] - x["ohlc"]["close"]) / x["ohlc"]["close"])*100] 
-        if x['ohlc']['close'] != 0 else [x['last_price'],x['ohlc']['close'],None] , axis=1)
+                ).apply(
+                    lambda x: [
+                    x['prev_close'],
+                    x['close'],
+                    x['prev_close']-x['close'],
+                    (x["close"] - x["prev_close"]) / x["prev_close"] * 100]
+                    if x["prev_close"] != 0
+                    else [x["prev_close"], x["close"], None, None],
+                    axis=1,
+                )
+                # breakpoint()
+                res_df = pd.DataFrame(
+                    res_df.to_list(),
+                    index=res_indx,
+                    columns=["prev_close", "curr_close", "diff", "percent_diff"],
+                )
+                # breakpoint()
+                res_df.dropna(inplace=True)
+                res_df.sort_values(by="percent_diff", ascending=False, inplace=True)
+                res_df = res_df.round(2)
+                # breakpoint()
+                return res_df
 
-        res_df = pd.DataFrame(res_df.to_list(),
-            index=res_df.index.to_series().apply(lambda x: x.split(":")[1]).tolist(),
-            columns=["prev_close","curr_close","diff","percent_diff"])
 
-        res_df.dropna(inplace=True)
-        res_df.sort_values(by="percent_diff",ascending=False, inplace=True)
-        res_df = res_df.round(2)
-        # breakpoint()
-        return res_df
+        elif from_date is not None:
+            pass
+        elif to_date is not None:
+            # Would there be a scenario where this is the case??
+            pass 
+
 
         
 

--- a/api/classes.py
+++ b/api/classes.py
@@ -474,7 +474,6 @@ class KiteFunctions(KiteAuthentication):
         #**********************************************************************************************************
         #**********************************************************************************************************
         if (from_date is None) and (to_date is None):
-            # print("From to dates none")
             stock_df = None
             if gnlr_type == "STOCKS":
                 stock_df = (
@@ -516,7 +515,7 @@ class KiteFunctions(KiteAuthentication):
                         )
                     )
                 ]
-                # breakpoint()
+                
                 stock_df = pd.concat(
                     [
                         stock_df,
@@ -526,7 +525,6 @@ class KiteFunctions(KiteAuthentication):
                 )
                 stock_df.columns.values[-1] = "exchange_tradingsymbol"
 
-        # if from_date is None and to_date is None:
             res_df = (
                 pd.DataFrame(self.kite.quote(stock_df["exchange_tradingsymbol"].tolist()))
                 .transpose()
@@ -552,7 +550,7 @@ class KiteFunctions(KiteAuthentication):
             res_df.dropna(inplace=True)
             res_df.sort_values(by="percent_diff", ascending=False, inplace=True)
             res_df = res_df.round(2)
-            # breakpoint()
+            
             return res_df
 
         #**********************************************************************************************************
@@ -568,9 +566,9 @@ class KiteFunctions(KiteAuthentication):
                                     from_date
                                 ),
                             )
-                    # breakpoint()
+                    
                     res_df.index = res_df.apply(lambda x: "NSE:" + x["ticker"], axis=1)
-                    # breakpoint()
+                    
                     res_df = pd.concat(
                         [
                             res_df,
@@ -583,23 +581,23 @@ class KiteFunctions(KiteAuthentication):
                         lambda x: [
                         x['close'],
                         x['last_price'],
-                        x['close']-x['last_price'],
-                        (x["close"] - x["last_price"]) / x["close"] * 100]
+                        x['last_price']-x['close'],
+                        (x["last_price"]-x["close"]) / x["close"] * 100]
                         if x["close"] != 0
                         else [x["close"], x["last_price"], None, None],
                         axis=1,
                     )
-                    # breakpoint()
+                    
                     res_df = pd.DataFrame(
                         res_df.to_list(),
                         index=res_df.index.to_series().apply(lambda x: x.split(":")[1]).tolist(),
                         columns=["prev_close", "curr_close", "diff", "percent_diff"],
                     )
-                    # breakpoint()
+                    
                     res_df.dropna(inplace=True)
                     res_df.sort_values(by="percent_diff", ascending=False, inplace=True)
                     res_df = res_df.round(2)
-                    # breakpoint()
+                    
                     return res_df
 
                 elif gnlr_type == "INDICES":
@@ -609,9 +607,9 @@ class KiteFunctions(KiteAuthentication):
                                     from_date
                                 ),
                             )
-                    # breakpoint()
+                
                     res_df.index = res_df.apply(lambda x: "NSE:" + x["ticker"], axis=1)
-                    # breakpoint()
+                    
                     res_df = pd.concat(
                         [
                             res_df,
@@ -624,23 +622,23 @@ class KiteFunctions(KiteAuthentication):
                         lambda x: [
                         x['close'],
                         x['last_price'],
-                        x['close']-x['last_price'],
-                        (x["close"] - x["last_price"]) / x["close"] * 100]
+                        x['last_price']-x['close'],
+                        (x["last_price"]-x["close"]) / x["close"] * 100]
                         if x["close"] != 0
                         else [x["close"], x["last_price"], None, None],
                         axis=1,
                     )
-                    # breakpoint()
+                    
                     res_df = pd.DataFrame(
                         res_df.to_list(),
                         index=res_df.index.to_series().apply(lambda x: x.split(":")[1]).tolist(),
                         columns=["prev_close", "curr_close", "diff", "percent_diff"],
                     )
-                    # breakpoint()
+                    
                     res_df.dropna(inplace=True)
                     res_df.sort_values(by="percent_diff", ascending=False, inplace=True)
                     res_df = res_df.round(2)
-                    # breakpoint()
+                    
                     return res_df
 
                 elif gnlr_type == "FUTURES": 
@@ -653,9 +651,9 @@ class KiteFunctions(KiteAuthentication):
                                     expiry_date
                                 ),
                             )
-                    # breakpoint()
+                    
                     res_df.index = res_df.apply(lambda x: "NFO:" + x["ticker"], axis=1)
-                    # breakpoint()
+                    
                     res_df = pd.concat(
                         [
                             res_df,
@@ -668,23 +666,23 @@ class KiteFunctions(KiteAuthentication):
                         lambda x: [
                         x['close'],
                         x['last_price'],
-                        x['close']-x['last_price'],
-                        (x["close"] - x["last_price"]) / x["close"] * 100]
+                        x['last_price']-x['close'],
+                        (x["last_price"]-x["close"]) / x["close"] * 100]
                         if x["close"] != 0
                         else [x["close"], x["last_price"], None, None],
                         axis=1,
                     )
-                    # breakpoint()
+                    
                     res_df = pd.DataFrame(
                         res_df.to_list(),
                         index=res_df.index.to_series().apply(lambda x: x.split(":")[1]).tolist(),
                         columns=["prev_close", "curr_close", "diff", "percent_diff"],
                     )
-                    # breakpoint()
+                    
                     res_df.dropna(inplace=True)
                     res_df.sort_values(by="percent_diff", ascending=False, inplace=True)
                     res_df = res_df.round(2)
-                    # breakpoint()
+                    
                     return res_df
             else:
 
@@ -695,10 +693,10 @@ class KiteFunctions(KiteAuthentication):
                                     from_date
                                 ),
                             )
-                    # breakpoint()
+                    
                     res_df.columns.values[6] = "prev_close"
                     res_indx = res_df['ticker']
-                    # breakpoint()
+                    
                     res_df = pd.concat(
                     [
                         res_df,
@@ -714,23 +712,23 @@ class KiteFunctions(KiteAuthentication):
                         lambda x: [
                         x['prev_close'],
                         x['close'],
-                        x['prev_close']-x['close'],
+                        x['close']-x['prev_close'],
                         (x["close"] - x["prev_close"]) / x["prev_close"] * 100]
                         if x["prev_close"] != 0
                         else [x["prev_close"], x["close"], None, None],
                         axis=1,
                     )
-                    # breakpoint()
+                    
                     res_df = pd.DataFrame(
                         res_df.to_list(),
                         index=res_indx,
                         columns=["prev_close", "curr_close", "diff", "percent_diff"],
                     )
-                    # breakpoint()
+                    
                     res_df.dropna(inplace=True)
                     res_df.sort_values(by="percent_diff", ascending=False, inplace=True)
                     res_df = res_df.round(2)
-                    # breakpoint()
+                    
                     return res_df
 
                 elif gnlr_type == "INDICES":
@@ -740,10 +738,10 @@ class KiteFunctions(KiteAuthentication):
                                     from_date
                                 ),
                             )
-                    # breakpoint()
+                    
                     res_df.columns.values[6] = "prev_close"
                     res_indx = res_df['ticker']
-                    # breakpoint()
+                    
                     res_df = pd.concat(
                     [
                         res_df,
@@ -759,23 +757,23 @@ class KiteFunctions(KiteAuthentication):
                         lambda x: [
                         x['prev_close'],
                         x['close'],
-                        x['prev_close']-x['close'],
+                        x['close']-x['prev_close'],
                         (x["close"] - x["prev_close"]) / x["prev_close"] * 100]
                         if x["prev_close"] != 0
                         else [x["prev_close"], x["close"], None, None],
                         axis=1,
                     )
-                    # breakpoint()
+                    
                     res_df = pd.DataFrame(
                         res_df.to_list(),
                         index=res_indx,
                         columns=["prev_close", "curr_close", "diff", "percent_diff"],
                     )
-                    # breakpoint()
+                    
                     res_df.dropna(inplace=True)
                     res_df.sort_values(by="percent_diff", ascending=False, inplace=True)
                     res_df = res_df.round(2)
-                    # breakpoint()
+                    
                     return res_df
 
                 elif gnlr_type == "FUTURES": # 7.32 secs number -> 5
@@ -788,10 +786,10 @@ class KiteFunctions(KiteAuthentication):
                                     expiry_date
                                 ),
                             )
-                    # breakpoint()
+                    
                     res_df.columns.values[6] = "prev_close"
                     res_indx = res_df['ticker']
-                    # breakpoint()
+                    
                     res_df = pd.concat(
                     [
                         res_df,
@@ -810,23 +808,23 @@ class KiteFunctions(KiteAuthentication):
                         lambda x: [
                         x['prev_close'],
                         x['close'],
-                        x['prev_close']-x['close'],
+                        x['close']-x['prev_close'],
                         (x["close"] - x["prev_close"]) / x["prev_close"] * 100]
                         if x["prev_close"] != 0
                         else [x["prev_close"], x["close"], None, None],
                         axis=1,
                     )
-                    # breakpoint()
+                    
                     res_df = pd.DataFrame(
                         res_df.to_list(),
                         index=res_indx,
                         columns=["prev_close", "curr_close", "diff", "percent_diff"],
                     )
-                    # breakpoint()
+                    
                     res_df.dropna(inplace=True)
                     res_df.sort_values(by="percent_diff", ascending=False, inplace=True)
                     res_df = res_df.round(2)
-                    # breakpoint()
+                    
                     return res_df
 
 
@@ -838,9 +836,9 @@ class KiteFunctions(KiteAuthentication):
                                 from_date
                             ),
                         )
-                # breakpoint()
+                
                 res_df.index = res_df.apply(lambda x: "NSE:" + x["ticker"], axis=1)
-                # breakpoint()
+                
                 res_df = pd.concat(
                     [
                         res_df,
@@ -851,25 +849,25 @@ class KiteFunctions(KiteAuthentication):
                     axis=1,
                 ).apply(
                     lambda x: [
-                   x['close'],
-                    x['last_price'],
-                    x['close']-x['last_price'],
-                    (x["close"] - x["last_price"]) / x["close"] * 100]
+                        x['close'],
+                        x['last_price'],
+                        x['last_price']-x['close'],
+                        (x["last_price"]-x["close"]) / x["close"] * 100]
                     if x["close"] != 0
                     else [x["close"], x["last_price"], None, None],
                     axis=1,
                 )
-                # breakpoint()
+                
                 res_df = pd.DataFrame(
                     res_df.to_list(),
                     index=res_df.index.to_series().apply(lambda x: x.split(":")[1]).tolist(),
                     columns=["prev_close", "curr_close", "diff", "percent_diff"],
                 )
-                # breakpoint()
+                
                 res_df.dropna(inplace=True)
                 res_df.sort_values(by="percent_diff", ascending=False, inplace=True)
                 res_df = res_df.round(2)
-                # breakpoint()
+                
                 return res_df
 
             elif gnlr_type == "INDICES":
@@ -879,9 +877,9 @@ class KiteFunctions(KiteAuthentication):
                                 from_date
                             ),
                         )
-                # breakpoint()
+                
                 res_df.index = res_df.apply(lambda x: "NSE:" + x["ticker"], axis=1)
-                # breakpoint()
+                
                 res_df = pd.concat(
                     [
                         res_df,
@@ -892,25 +890,25 @@ class KiteFunctions(KiteAuthentication):
                     axis=1,
                 ).apply(
                     lambda x: [
-                   x['close'],
-                    x['last_price'],
-                    x['close']-x['last_price'],
-                    (x["close"] - x["last_price"]) / x["close"] * 100]
+                        x['close'],
+                        x['last_price'],
+                        x['last_price']-x['close'],
+                        (x["last_price"]-x["close"]) / x["close"] * 100]
                     if x["close"] != 0
                     else [x["close"], x["last_price"], None, None],
                     axis=1,
                 )
-                # breakpoint()
+                
                 res_df = pd.DataFrame(
                     res_df.to_list(),
                     index=res_df.index.to_series().apply(lambda x: x.split(":")[1]).tolist(),
                     columns=["prev_close", "curr_close", "diff", "percent_diff"],
                 )
-                # breakpoint()
+                
                 res_df.dropna(inplace=True)
                 res_df.sort_values(by="percent_diff", ascending=False, inplace=True)
                 res_df = res_df.round(2)
-                # breakpoint()
+                
                 return res_df
 
             elif gnlr_type == "FUTURES": 
@@ -923,9 +921,9 @@ class KiteFunctions(KiteAuthentication):
                                 expiry_date
                             ),
                         )
-                # breakpoint()
+                
                 res_df.index = res_df.apply(lambda x: "NFO:" + x["ticker"], axis=1)
-                # breakpoint()
+                
                 res_df = pd.concat(
                     [
                         res_df,
@@ -936,27 +934,30 @@ class KiteFunctions(KiteAuthentication):
                     axis=1,
                 ).apply(
                     lambda x: [
-                   x['close'],
-                    x['last_price'],
-                    x['close']-x['last_price'],
-                    (x["close"] - x["last_price"]) / x["close"] * 100]
+                        x['close'],
+                        x['last_price'],
+                        x['last_price']-x['close'],
+                        (x["last_price"]-x["close"]) / x["close"] * 100]
                     if x["close"] != 0
                     else [x["close"], x["last_price"], None, None],
                     axis=1,
                 )
-                # breakpoint()
+                
                 res_df = pd.DataFrame(
                     res_df.to_list(),
                     index=res_df.index.to_series().apply(lambda x: x.split(":")[1]).tolist(),
                     columns=["prev_close", "curr_close", "diff", "percent_diff"],
                 )
-                # breakpoint()
+                
                 res_df.dropna(inplace=True)
                 res_df.sort_values(by="percent_diff", ascending=False, inplace=True)
                 res_df = res_df.round(2)
-                # breakpoint()
-                return res_df
                 
+                return res_df
+
+        #**********************************************************************************************************
+        #**********************************************************************************************************
+
 
         
 

--- a/api/urls.py
+++ b/api/urls.py
@@ -16,5 +16,6 @@ urlpatterns = [
    url( r'^straddleprices/?$', views.Get_Straddle_Prices.as_view(),name ='straddle') ,
    url( r'^strangleprices/?$', views.Get_Strangle_Prices.as_view(),name ='strangle') ,
    url( r'^gainerslosers/?$', views.Gainers_Losers.as_view(),name ='gainerslosers') ,
+   url( r'^gainerslosersoi/?$', views.Gainers_Losers_OI.as_view(),name ='gainerslosersoi') ,
    url( r'$', views.Home, name ='home'),
 ]

--- a/api/urls.py
+++ b/api/urls.py
@@ -15,5 +15,6 @@ urlpatterns = [
    url( r'^ltp/?$', views.Get_ltp_ticker.as_view(),name ='ltp') ,
    url( r'^straddleprices/?$', views.Get_Straddle_Prices.as_view(),name ='straddle') ,
    url( r'^strangleprices/?$', views.Get_Strangle_Prices.as_view(),name ='strangle') ,
+   url( r'^gainerslosers/?$', views.Gainers_Losers.as_view(),name ='gainerslosers') ,
    url( r'$', views.Home, name ='home'),
 ]

--- a/api/urls.py
+++ b/api/urls.py
@@ -14,5 +14,6 @@ urlpatterns = [
    url( r'^kiteauth/?$', views.Get_KiteAuth.as_view(),name ='kiteauth') ,
    url( r'^ltp/?$', views.Get_ltp_ticker.as_view(),name ='ltp') ,
    url( r'^straddleprices/?$', views.Get_Straddle_Prices.as_view(),name ='straddle') ,
+   url( r'^strangleprices/?$', views.Get_Strangle_Prices.as_view(),name ='strangle') ,
    url( r'$', views.Home, name ='home'),
 ]

--- a/api/urls.py
+++ b/api/urls.py
@@ -13,5 +13,6 @@ urlpatterns = [
    url( r'^montecarlo/?$', views.Get_MonteCarlo_Simulation.as_view(),name ='montecarlo') ,
    url( r'^kiteauth/?$', views.Get_KiteAuth.as_view(),name ='kiteauth') ,
    url( r'^ltp/?$', views.Get_ltp_ticker.as_view(),name ='ltp') ,
+   url( r'^straddleprices/?$', views.Get_Straddle_Prices.as_view(),name ='straddle') ,
    url( r'$', views.Home, name ='home'),
 ]

--- a/api/views.py
+++ b/api/views.py
@@ -928,6 +928,9 @@ class Gainers_Losers(APIView):
                 expiry_date = datetime.strptime(
                     request.data.get("expiry_date", None), "%Y-%m-%d"
                 ).date()
+
+            from_date = request.data.get("from_date", None)
+            to_date = request.data.get("to_date", None)
         except Exception as e:
             return "Error encountered while reading input request:\n" + str(e)
 
@@ -939,7 +942,17 @@ class Gainers_Losers(APIView):
         stock_df = None
         if gnlr_type in ["STOCK", "STOCKS"]:
             gnlr_type = "STOCKS"
-        res_df = kf.get_gainers_losers_close_df(gnlr_type, expiry_date)
+
+        if from_date is not None:
+            from_date = datetime.strptime(
+                    from_date, "%Y-%m-%d"
+                ).date()
+        if to_date is not None:
+            to_date = datetime.strptime(
+                    to_date, "%Y-%m-%d"
+                ).date()
+
+        res_df = kf.get_gainers_losers_close_df(gnlr_type, expiry_date,from_date,to_date)
 
         if ret_df:
             if gainers_or_losers == "GAINERS":
@@ -1039,7 +1052,6 @@ class Gainers_Losers(APIView):
         ####################### chartjs ########################
         return Response(json.loads(NewChart.get()))
 
-
 class Gainers_Losers_OI(APIView):
     def post(self, request):
         # ********************************* INPUT PARAMS *******************************************
@@ -1122,7 +1134,7 @@ class Gainers_Losers_OI(APIView):
                     res_df,
                     kf.ka.pg.get_postgres_data_df_with_condition(
                         table_name="stock_futures_history_day",
-                        where_condition="where CAST(date AS DATE) = '{}' and CAST(expiry_date as DATE) = '{}'".format(
+                        where_condition="where CAST(last_update AS DATE) = '{}' and CAST(expiry_date as DATE) = '{}'".format(
                             ltd.strftime("%Y-%m-%d"), expiry_date.strftime("%Y-%m-%d")
                         ),
                     ),

--- a/srifintechbackend/settings.py
+++ b/srifintechbackend/settings.py
@@ -28,12 +28,12 @@ SECRET_KEY = os.getenv("DJANGO_SECRET_KEY", get_random_secret_key())
 # SECURITY WARNING: don't run with debug turned on in production!
                        
 #                            > make this value True in for local run
-DEBUG = os.getenv("DEBUG", "False") == "True"
+DEBUG = os.getenv("DEBUG", "True") == "True"
 
 ALLOWED_HOSTS = os.getenv("DJANGO_ALLOWED_HOSTS", "127.0.0.1,localhost").split(",")
 
 #                            > make this value True in for local run
-DEVELOPMENT_MODE = os.getenv("DEVELOPMENT_MODE", "False") == "True"
+DEVELOPMENT_MODE = os.getenv("DEVELOPMENT_MODE", "True") == "True"
 
 # Application definition
 


### PR DESCRIPTION
## What?

The gainers losers API can also return the top
Futures Gainers and Top Futures Losers on a particular
expiry date. The expiry date is required only when
Fetching the Gainers and Losers for Futures.

Example requests:

### 1.
{
    "number":5,
    "gainers_or_losers":"both",
    "type":"futures",
    "expiry_date":"2021-07-29"
}

Returns top 5 gainers and losers for futures for the expiry
"2021-07-29"

### 2.
{
    "number":0,
    "gainers_or_losers":"losers",
    "type":"futures",
    "expiry_date":"2021-07-29"
}
Returns top all losers for futures for the expiry
"2021-07-29"

### 3.
{
    "number":10,
    "gainers_or_losers":"losers",
    "type":"indices",
}
Returns 10 gainers of nifty indices