### PR TITLE
Added Cash Futures Arbitrage Api

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -14,5 +14,6 @@ urlpatterns = [
    url( r'^kiteauth/?$', views.Get_KiteAuth.as_view(),name ='kiteauth') ,
    url( r'^ltp/?$', views.Get_ltp_ticker.as_view(),name ='ltp') ,
    url( r'^optionchain/?$', views.Option_Chain.as_view(),name ='optionchain') ,
+   url( r'^cashfutarbitrage/?$', views.Cash_Futures_Arbitrage.as_view(),name ='cashfutarbitrage') ,
    url( r'$', views.Home, name ='home'),
 ]

--- a/api/views.py
+++ b/api/views.py
@@ -1504,6 +1504,14 @@ class Gainers_Losers_OI(APIView):
         
 class Cash_Futures_Arbitrage(APIView):
     def post(self,request):
+
+        # ********************************* INPUT PARAMS *******************************************
+        try:
+            chart_js = request.data.get("chart_js", False)
+        except Exception as e:
+            return Response({"Error encountered while reading input request:\n": str(e)})
+
+        # ********************************** INPUT PARAMS ******************************************
         kf = KiteFunctions()
         exclude_list = ["NIFTY","FINNIFTY","BANKNIFTY"]
         stock_df = kf.master_instruments_df[(kf.master_instruments_df["segment"]=="NFO-FUT")
@@ -1547,11 +1555,30 @@ class Cash_Futures_Arbitrage(APIView):
             None,
             None],axis=1)
 
-        stock_df = pd.DataFrame(stock_df.to_list(),columns = ["FNO Stocks","Stock Price","Futures Price","Price Change","Change in %"])
+        stock_df = pd.DataFrame(stock_df.to_list(),columns = ["FNO Stocks","Stock Price",
+            "Futures Price","Price Change","Difference in %"])
 
         stock_df.index = stock_df['FNO Stocks']
 
         stock_df.drop(labels=["FNO Stocks"],axis=1,inplace=True)
 
         stock_df = stock_df.round(2)
-        return Response(stock_df.to_dict("index"))
+        stock_df.sort_values(by="Difference in %",ascending=False, inplace=True)
+        if not chart_js:
+            return Response(stock_df.to_dict("index"))
+        else:
+            ####################### chartjs ########################
+            cfa_bargraph = gl_bargraph
+
+            NewChart = cfa_bargraph(
+                data1=stock_df["Difference in %"].tolist(),
+                yaxis_labels= stock_df.index.tolist(),
+                y_label="Stocks",
+                top_label="Cash Futures Arbitrage",
+                barcolor="BOTH",
+                position="left",
+                len1=len(stock_df[stock_df["Difference in %"] > 0].index),
+                len2=len(stock_df[stock_df["Difference in %"] <= 0].index),
+            )()
+            ####################### chartjs ########################
+            return Response(json.loads(NewChart.get()))

--- a/api/views.py
+++ b/api/views.py
@@ -574,7 +574,6 @@ class Get_ltp_ticker(APIView):
     def get(self , request):
         return Response({'ticker':'NIFTY'})
 
-
 class Option_Chain(APIView):
     def post(self, request):
         # ********************************* INPUT PARAMS *******************************************
@@ -731,5 +730,7 @@ class Option_Chain(APIView):
             .to_dict()
         )
 
-
+class Cash_Fututres_Arbitrage(APIView):
+    def post(self,request):
+        return Response({"statusCode":200})
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -21,6 +21,7 @@
     <h2> strangle api - <a href="{% url 'strangle' %}">strangle</a></h2>
     <h2> gainerslosers api - <a href="{% url 'gainerslosers' %}">gainerslosers</a></h2>
     <h2> gainerslosersoi api - <a href="{% url 'gainerslosersoi' %}">gainerslosersoi</a></h2>
+    <h2> cashfutarbitrage api - <a href="{% url 'cashfutarbitrage' %}">cashfutarbitrage</a></h2>
 
 
 </body>


### PR DESCRIPTION
## What?
SRIF-134 : https://srifintech.atlassian.net/browse/SRIF-134

### 1.
Api returns the json output consisting of the following fields:

> ["FNO Stocks","Stock Price","Futures Price","Price Change","Difference in %"]

Sample output:

```
{
    "ITC": {
        "Stock Price": 213.9,
        "Futures Price": 208.75,
        "Price Change": 5.15,
        "Difference in %": 2.41
    },
    "TATASTEEL": {
        "Stock Price": 1115.8,
        "Futures Price": 1096.55,
        "Price Change": 19.25,
        "Difference in %": 1.73
    },
    "TORNTPOWER": {
        "Stock Price": 477.65,
        "Futures Price": 472.05,
        "Price Change": 5.6,
        "Difference in %": 1.17
    },
    "NAM-INDIA": {
        "Stock Price": 380.85,
        "Futures Price": 376.75,
        "Price Change": 4.1,
        "Difference in %": 1.08
    },
    "TATAPOWER": {
        "Stock Price": 123.8,
        "Futures Price": 122.55,
        "Price Change": 1.25,
        "Difference in %": 1.01
    },
     .....

}

```

### 2.
Added optional parameter `chart_js` to cash futures arbitrage api

Default value is `false`. When set to `true`, returns a response of
chart json. The chart json would be a bargraph with the
`Difference in %` values shown as the bars.

When `false` it returns the normal `json` response of the dataframe.