### PR TITLE
Added "combined" line in straddle and strangle

### DIFF
--- a/api/chartjs_classes.py
+++ b/api/chartjs_classes.py
@@ -362,8 +362,8 @@ def maxpain_linegraph(label_ticker,scale_label_str):
                 fill            = False
                 yAxisID      = 'y1'
                 lineTension  = 0
-                pointStyle = 'triangle'
-                borderDash    = [3, 1] 
+                # pointStyle = 'triangle'
+                # borderDash    = [3, 1] 
                 #Point Properties
                 pointRadius  = 1
 
@@ -497,8 +497,8 @@ def pcr_linegraph(label_ticker,scale_label_str):
                 fill            = False
                 yAxisID      = 'y1'
                 lineTension  = 0
-                pointStyle = 'triangle'
-                borderDash    = [3, 1] 
+                # pointStyle = 'triangle'
+                # borderDash    = [3, 1] 
                 #Point Properties
                 pointRadius  = 1
 

--- a/api/views.py
+++ b/api/views.py
@@ -1403,7 +1403,7 @@ class Get_Straddle_Prices(APIView):
             return Response({"Error encountered while reading input request:\n": str(e)})
         straddle_strike_list = content.get("strikes_list", [])
         intraday_ind = content.get("intraday_ind", True)
-        combined = content.get("combined",False)
+        combined = content.get("combined",True)
         ####################### Input parameters #####################
 
         try:
@@ -1519,7 +1519,7 @@ class Get_Straddle_Prices(APIView):
 
         if combined:
             final_straddle_df["Combined"] = final_straddle_df[straddle_strike_list].sum(axis=1)
-            straddle_strike_list.append("Combined")
+            straddle_strike_list.insert(0,"Combined")
 
         ############################ chartjs ##########################
         straddle_linegraph = strangle_linegraph
@@ -1583,7 +1583,7 @@ class Get_Strangle_Prices(APIView):
         except Exception as e:
             return Response({"Error encountered while reading input request:\n": str(e)})
         intraday_ind = content.get("intraday_ind", True)
-        combined = content.get("combined",False)
+        combined = content.get("combined",True)
         ####################### Input parameters #####################
 
         days = 10
@@ -1710,7 +1710,7 @@ class Get_Strangle_Prices(APIView):
         logging.debug(pformat(final_strangle_df))
         if combined:
             final_strangle_df["Combined"] = final_strangle_df[ [i['label'] for i in strangle_strike_list] ].sum(axis=1)
-            strangle_strike_list.append({'label': "Combined"})
+            strangle_strike_list.insert(0,{'label': "Combined"})
 
         ####################### chartjs ########################
         NewChart = strangle_linegraph(

--- a/api/views.py
+++ b/api/views.py
@@ -1583,6 +1583,7 @@ class Get_Strangle_Prices(APIView):
         except Exception as e:
             return Response({"Error encountered while reading input request:\n": str(e)})
         intraday_ind = content.get("intraday_ind", True)
+        combined = content.get("combined",False)
         ####################### Input parameters #####################
 
         days = 10
@@ -1707,6 +1708,9 @@ class Get_Strangle_Prices(APIView):
         )
 
         logging.debug(pformat(final_strangle_df))
+        if combined:
+            final_strangle_df["Combined"] = final_strangle_df[ [i['label'] for i in strangle_strike_list] ].sum(axis=1)
+            strangle_strike_list.append({'label': "Combined"})
 
         ####################### chartjs ########################
         NewChart = strangle_linegraph(

--- a/api/views.py
+++ b/api/views.py
@@ -1403,6 +1403,7 @@ class Get_Straddle_Prices(APIView):
             return Response({"Error encountered while reading input request:\n": str(e)})
         straddle_strike_list = content.get("strikes_list", [])
         intraday_ind = content.get("intraday_ind", True)
+        combined = content.get("combined",False)
         ####################### Input parameters #####################
 
         try:
@@ -1515,6 +1516,10 @@ class Get_Straddle_Prices(APIView):
             final_straddle_df.index = final_straddle_df.index.strftime("%H:%M")
         else:
             final_straddle_df.index = final_straddle_df.index.strftime("%b-%d")
+
+        if combined:
+            final_straddle_df["Combined"] = final_straddle_df[straddle_strike_list].sum(axis=1)
+            straddle_strike_list.append("Combined")
 
         ############################ chartjs ##########################
         straddle_linegraph = strangle_linegraph


### PR DESCRIPTION
## What?
#### Added `combined` parameter in `straddle` and `strangle` API:
- Combined parameter when set to `true` would return the sum of
all the straddle/strangle prices as a separate line labeled as
`Combined`.
- Default value is `true` for this parameter
- Combined line was made to precede the other lines
#### Straddle Example:
![ques53](https://user-images.githubusercontent.com/28010398/124549805-5384eb00-de4d-11eb-86ac-7f66b9bf5b80.png)
#### Strangle Example:
![ques54](https://user-images.githubusercontent.com/28010398/124549903-7b744e80-de4d-11eb-9677-d8860226d1a8.png)

